### PR TITLE
fix: 修复table插件在readOnly模式下依然可以修改的bug

### DIFF
--- a/playground/index.jsx
+++ b/playground/index.jsx
@@ -17,6 +17,8 @@ BraftEditor.use(Table({
 
 BraftEditor.use(Markdown())
 
+// const data = '{"blocks":[{"key":"fsbqp","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"3kash","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"1p6j3","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":0,"rowIndex":0,"colSpan":1,"rowSpan":1}},{"key":"r4mi","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":1,"rowIndex":0,"colSpan":1,"rowSpan":1}},{"key":"7mlm","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":2,"rowIndex":0,"colSpan":1,"rowSpan":1}},{"key":"5bpms","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":3,"rowIndex":0,"colSpan":1,"rowSpan":1}},{"key":"evodm","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":0,"rowIndex":1,"colSpan":1,"rowSpan":1}},{"key":"4uiao","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":1,"rowIndex":1,"colSpan":1,"rowSpan":1}},{"key":"65fv3","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":2,"rowIndex":1,"colSpan":1,"rowSpan":1}},{"key":"49aag","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":3,"rowIndex":1,"colSpan":1,"rowSpan":1}},{"key":"c9a5p","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}'
+
 BraftEditor.use(ColorPicker())
 
 class Demo extends React.Component {
@@ -36,6 +38,7 @@ class Demo extends React.Component {
   }
 
   handleChange = (editorState) => {
+    console.log(editorState.toRAW());
     this.setState({ editorState })
   }
 

--- a/playground/index.jsx
+++ b/playground/index.jsx
@@ -17,8 +17,6 @@ BraftEditor.use(Table({
 
 BraftEditor.use(Markdown())
 
-// const data = '{"blocks":[{"key":"fsbqp","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"3kash","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"1p6j3","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":0,"rowIndex":0,"colSpan":1,"rowSpan":1}},{"key":"r4mi","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":1,"rowIndex":0,"colSpan":1,"rowSpan":1}},{"key":"7mlm","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":2,"rowIndex":0,"colSpan":1,"rowSpan":1}},{"key":"5bpms","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":3,"rowIndex":0,"colSpan":1,"rowSpan":1}},{"key":"evodm","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":0,"rowIndex":1,"colSpan":1,"rowSpan":1}},{"key":"4uiao","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":1,"rowIndex":1,"colSpan":1,"rowSpan":1}},{"key":"65fv3","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":2,"rowIndex":1,"colSpan":1,"rowSpan":1}},{"key":"49aag","text":"","type":"table-cell","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"tableKey":"bu0be","colIndex":3,"rowIndex":1,"colSpan":1,"rowSpan":1}},{"key":"c9a5p","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}'
-
 BraftEditor.use(ColorPicker())
 
 class Demo extends React.Component {
@@ -38,7 +36,6 @@ class Demo extends React.Component {
   }
 
   handleChange = (editorState) => {
-    console.log(editorState.toRAW());
     this.setState({ editorState })
   }
 

--- a/src/table/render.jsx
+++ b/src/table/render.jsx
@@ -814,6 +814,7 @@ export class Table extends React.Component {
   render () {
 
     const { tableRows, dragSelecting, draggingRectBounding } = this.state
+    const { readOnly } = this.props.editor.props;
 
     return (
       <div className="bf-table-container">
@@ -835,8 +836,8 @@ export class Table extends React.Component {
         </table>
         {dragSelecting ? <div className="dragging-rect" style={draggingRectBounding}/> : null}
         {this.createContextMenu()}
-        {this.createColTools()}
-        {this.createRowTools()}
+        {!readOnly && this.createColTools()}
+        {!readOnly && this.createRowTools()}
       </div>
     )
 


### PR DESCRIPTION
解决Issue：[在开启readOnly的编辑器中表格仍然可编辑 #33](https://github.com/margox/braft-extensions/issues/33)