### PR TITLE
fix(table): columngroup closing tag removed <

### DIFF
--- a/src/table/converts.js
+++ b/src/table/converts.js
@@ -14,7 +14,7 @@ const parseColgoupData = (colgroupNode) => {
 
 const buildColgroup = (blockData) => {
   if (blockData && blockData.colgroupData && blockData.colgroupData.length) {
-    return `<colgroup>${blockData.colgroupData.map(col => `<col width="${col.width}"></col>`).join('')}</<colgroup>`
+    return `<colgroup>${blockData.colgroupData.map(col => `<col width="${col.width}"></col>`).join('')}</colgroup>`
   }
 
   return ''


### PR DESCRIPTION
Otherwise the output of a resized table is:
```
<table>
    <colgroup>
        <col width="789"></col>
        <col width="1457"></col>
    </<colgroup>         <!------------ This should be </colgroup> ------------->
    <tr>
        <td colSpan="1" rowSpan="1"></td>
        <td colSpan="1" rowSpan="1"></td>
    </tr>
</table>
```