### PR TITLE
feat: mention 扩展模块

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,3 +269,54 @@ const options = {
 
 BraftEditor.use(HeaderId(options))
 ```
+
+## Mention 模块
+基于 [draft-js-mention](https://github.com/draft-js-plugins/draft-js-plugins/tree/master/packages/mention) 实现的 Mention 功能  
+`options` 除了可以使用 includeEditors 和 excludeEditors 指定和排除 editor 外，其余的参数请参考 draft-js-mention 的参数配置
+可参考 https://www.draft-js-plugins.com/plugin/mention
+
+#### 基本使用
+```ts
+import Mention from 'braft-extensions/dist/mention'
+
+interface MentionData {
+    link?: string;
+    avatar?: string;
+    name: string;
+    id?: null | string | number;
+}
+
+interface MentionSuggestionsPubProps {
+    suggestions: MentionData[];
+    open: boolean;
+    onOpenChange(open: boolean): void;
+    onSearchChange(event: { value: string }): void;
+    onAddMention(Mention: MentionData): void;
+}
+
+const options = {
+  includeEditors: ['editor-id-1'], // 指定该模块对哪些BraftEditor生效，不传此属性则对所有BraftEditor有效
+  excludeEditors: ['editor-id-2'],  // 指定该模块对哪些BraftEditor无效
+  mentionTrigger: '@'               // 可选参数。设置触发 mention 的符号，默认为 '@'
+}
+
+// Mention 方法返回一个二元祖
+// 第一个是 braft-extension 所用插件数据
+// 第二个是 控制 mention suggestions 的组件
+//          类型为 React.ComponentType<MentionSuggestionsPubProps>
+const [mentionExtension, MentionSuggestions] = Mention(options)
+BraftEditor.use(mentionExtension)
+
+
+const DemoEditor = (props) => {
+  // ... 省略
+
+  return (
+    <div>
+      <BraftEditor ... />
+      <MentionSuggestions ... />
+    </div>
+  )
+}
+
+```

--- a/build/webpack.production.js
+++ b/build/webpack.production.js
@@ -5,7 +5,7 @@ var merge = require('webpack-merge')
   , path = require('path')
   , baseConfigs = require('./webpack.base')
 
-var entryNames = ['code-highlighter', 'color-picker', 'emoticon', 'max-length', 'header-id', 'table', 'markdown']
+var entryNames = ['code-highlighter', 'color-picker', 'emoticon', 'max-length', 'header-id', 'table', 'markdown', 'mention']
 var entries = {
   index: './index.js'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "braft-extensions",
-  "version": "0.0.20",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3127,6 +3127,12 @@
         "shallow-clone": "^3.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npm.taobao.org/clsx/download/clsx-1.1.1.tgz",
+      "integrity": "sha1-mLMTT5q73yOyZjSRrOE8XAOnMYg=",
+      "dev": true
+    },
     "coa": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
@@ -4084,6 +4090,27 @@
         "fbjs": "^0.8.15",
         "immutable": "~3.7.4",
         "object-assign": "^4.1.0"
+      }
+    },
+    "draft-js-mention-plugin": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npm.taobao.org/draft-js-mention-plugin/download/draft-js-mention-plugin-3.1.5.tgz",
+      "integrity": "sha1-XudvxLTR4bLvmW/OyE/+VWXI0ak=",
+      "dev": true,
+      "requires": {
+        "clsx": "^1.0.4",
+        "immutable": "~3.7.4",
+        "lodash": "^4.17.14",
+        "prop-types": "^15.5.8",
+        "union-class-names": "^1.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npm.taobao.org/lodash/download/lodash-4.17.20.tgz?cache=0&sync_timestamp=1597339289624&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flodash%2Fdownload%2Flodash-4.17.20.tgz",
+          "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI=",
+          "dev": true
+        }
       }
     },
     "draft-js-multidecorators": {
@@ -11365,6 +11392,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+      "dev": true
+    },
+    "union-class-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/union-class-names/download/union-class-names-1.0.0.tgz",
+      "integrity": "sha1-kllgitrMOQlKKwz+FseOYgBheEc=",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cross-env": "^7.0.0",
     "css-loader": "^3.4.2",
     "draft-js-prism": "^1.0.6",
+    "draft-js-mention-plugin": "^3.1.5",
     "eslint": "^5.4.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-loader": "^2.1.0",

--- a/playground/index.jsx
+++ b/playground/index.jsx
@@ -7,6 +7,7 @@ import BraftEditor from 'braft-editor'
 import Table from '../src/table'
 import ColorPicker from '../src/color-picker'
 import Markdown from '../src/markdown'
+import Mention, { defaultSuggestionsFilter } from '../src/mention'
 
 BraftEditor.use(Table({
   defaultColumns: 4,
@@ -20,6 +21,43 @@ BraftEditor.use(Markdown())
 
 BraftEditor.use(ColorPicker())
 
+const [mentionExtension, MentionSuggestions] = Mention()
+BraftEditor.use(mentionExtension)
+
+/** test mention plugin mock data */
+const mentions = [
+  {
+      name: 'Matthew Russell',
+      link: 'https://twitter.com/mrussell247',
+      avatar: 'https://pbs.twimg.com/profile_images/517863945/mattsailing_400x400.jpg'
+  },
+  {
+      name: 'Julian Krispel-Samsel',
+      link: 'https://twitter.com/juliandoesstuff',
+      avatar: 'https://avatars2.githubusercontent.com/u/1188186?v=3&s=400'
+  },
+  {
+      name: 'Jyoti Puri',
+      link: 'https://twitter.com/jyopur',
+      avatar: 'https://avatars0.githubusercontent.com/u/2182307?v=3&s=400'
+  },
+  {
+      name: 'Max Stoiber',
+      link: 'https://twitter.com/mxstbr',
+      avatar: 'https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg'
+  },
+  {
+      name: 'Nik Graf',
+      link: 'https://twitter.com/nikgraf',
+      avatar: 'https://avatars0.githubusercontent.com/u/223045?v=3&s=400'
+  },
+  {
+      name: 'Pascal Brandt',
+      link: 'https://twitter.com/psbrandt',
+      avatar: 'https://pbs.twimg.com/profile_images/688487813025640448/E6O6I011_400x400.png'
+  }
+].map((item) => ({ ...item, id: item.name }))
+
 const tableStr = '<p></p><table border="1" style="border-collapse: collapse"><tr><td colSpan="1" rowSpan="1">ST-dstcollector	</td><td colSpan="1" rowSpan="1">80、12200</td></tr><tr><td colSpan="1" rowSpan="1">DST-dstweb		</td><td colSpan="1" rowSpan="1">80、83</td></tr></table><p></p>';
 const tableStr2 = '<table border="1" style="border-collapse: collapse"><colgroup><col width="120"></col><col width="240"></col></colgroup><tr><td colSpan="1" rowSpan="1">ST-dstcollector	</td><td colSpan="1" rowSpan="1">80、12200</td></tr><tr><td colSpan="1" rowSpan="1">DST-dstweb		</td><td colSpan="1" rowSpan="1">80、83</td></tr></table>';
 
@@ -30,7 +68,8 @@ class Demo extends React.Component {
     super(props)
 
     this.state = {
-      editorState: BraftEditor.createEditorState(tableStr2)
+      editorState: BraftEditor.createEditorState(tableStr2),
+      suggestions: mentions
     }
 
   }
@@ -42,6 +81,12 @@ class Demo extends React.Component {
   handleChange = (editorState) => {
     this.setState({ editorState })
   }
+
+  onSearchChange = ({ value }) => {
+    this.setState({
+      suggestions: defaultSuggestionsFilter(value, mentions),
+    });
+  };
 
   render() {
 
@@ -62,6 +107,10 @@ class Demo extends React.Component {
             value={editorState}
             contentStyle={{ height: 700 }}
           />
+            <MentionSuggestions
+                suggestions={this.state.suggestions}
+                onSearchChange={this.onSearchChange}
+            />
         </div>
       </div>
     )

--- a/src/mention/index.jsx
+++ b/src/mention/index.jsx
@@ -1,0 +1,138 @@
+import 'draft-js-mention-plugin/lib/plugin.css'
+import React from 'react'
+import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-plugin'
+
+/**
+ * 基于 draft-js-mention-plugin 的 mention 扩展
+ * 除了 includeEditors 和 excludeEditors 外
+ * 其他属性将会传递给 draft-js-mention-plugin
+ * 参考 https://www.draft-js-plugins.com/plugin/mention
+ */
+export default (options = {}) => {
+  const { includeEditors, excludeEditors, ...mentionPluginOptions } = options
+
+  const mentionPlugin = createMentionPlugin(mentionPluginOptions)
+
+  // MentionSuggestions 是一个 React Component 用来定制 mention 的数据
+  const { MentionSuggestions, ...draftEditorPlugin } = mentionPlugin
+
+  /**
+     * draft-js-plugin 为每个 plugin 的很多地方都注入了 get 和 set
+     * 在 braft-editor 里面 由于 在 useExtension 里面并拿不到 editor 的实例
+     * 只能在 prop-interception 的时候 有机会拿到 因此先用一个 对象引用起来 再传递
+     */
+  const getAndSetState = {
+    getEditorState: () => {
+      throw new Error('can\'t use get state')
+    },
+    setEditorState: (state) => {
+      throw new Error(`can't use set state ${state}`)
+    }
+  }
+
+  return [
+    [
+      {
+        type: 'prop-interception',
+        interceptor: (editorProps, editor) => {
+          // hack
+          // 没有地方可以有 init 的时机，属性拦截器这里会把编辑器的实例传过来
+          // 所以在这里初始化插件
+          getAndSetState.getEditorState = editor.getValue.bind(editor)
+          getAndSetState.setEditorState = editor.setValue.bind(editor)
+          if (draftEditorPlugin.initialize) {
+            // 这里 mention 插件 只用了 get/setEditor State 所以其他可以不传
+            draftEditorPlugin.initialize(getAndSetState)
+          }
+          // mention 的 plugin 需要 hack editor 的 onChange
+          // 如果有更好的办法请告知
+          const hackOnChange = editor.onChange
+          if (hackOnChange) {
+            editor.onChange = (editorState, callback) => {
+              hackOnChange.call(editor, editorState, callback)
+              if (draftEditorPlugin.onChange) {
+                draftEditorPlugin.onChange(editorState, getAndSetState)
+              }
+            }
+          }
+          
+          // 应该是 draft-js 和 draft-js-mention-plugin 之间的磨合除了问题
+          // mention 需要处理 以下几个键盘事件 但是 draft-js 对这几个事件有特殊处理
+          // 仅仅调用了 props 传递进去的 而不会通过 keyBindingFn 调用
+          // 所以这里额外处理，并通过 prop-interception 传递给 draftProps
+          // bug 可在 https://stackblitz.com/edit/draft-js-mention?file=index.tsx 使用 DraftEditor 复现
+          const passSomeKeyEventToKeyBindingFn = (props) => {
+            const handleName = [
+              'onUpArrow',
+              'onRightArrow',
+              'onDownArrow',
+              'onLeftArrow',
+              'onEscape',
+              'onTab'
+            ]
+            return handleName.reduce((acc, name) => {
+              const hackHandle = props[name]
+              const handler = (event) => {
+                if (typeof hackHandle === 'function') {
+                  hackHandle(event)
+                }
+                draftEditorPlugin.keyBindingFn(event, getAndSetState)
+              }
+              return {
+                ...acc,
+                [name]: handler
+              }
+            }, {})
+          }
+
+          return {
+            ...editorProps,
+            draftProps: {
+              ...editorProps.draftProps,
+              ...draftEditorPlugin.getAccessibilityProps(),
+              ...passSomeKeyEventToKeyBindingFn(editorProps.draftProps || {})
+            },
+            keyBindingFn: (event) => {
+              // 先处理前面插件的 keyBindingFn
+              // 暂时没有发现 mention 必须优先处理的必要性
+              const originHandler = editorProps.keyBindingFn
+              let ret = null
+              if (typeof originHandler === 'function') {
+                ret = originHandler(event)
+              }
+              return ret != null ? ret : draftEditorPlugin.keyBindingFn(event, getAndSetState)
+            },
+            handleReturn: (event, editorState, editor) => {
+              const originHandler = editorProps.handleReturn
+              // 这里 mention 要优于其他的插件处理 回车 事件
+              // 因为在 mention 弹出 suggestion 时 有「确认选择」的功能
+              if (draftEditorPlugin.handleReturn(event, editorState, getAndSetState) === 'handled') {
+                return 'handled'
+              }
+              return originHandler ? originHandler(event, editorState, editor) : 'not-handled'
+            }
+          }
+        }
+      },
+      ...(draftEditorPlugin.decorators || []).map((decorate) => {
+        return {
+          type: 'decorator',
+          includeEditors,
+          excludeEditors,
+          decorator: {
+            ...decorate,
+            component: (props) => {
+              // 这里需要注入 getAndSet 是因为平时 draft-js-plugin 里面 对所有的非自定义类型的装饰器进行了注入
+              // 所以这里也要模仿
+              // see draft-js-plugins/packages/editor/src/Editor/resolveDecorators.ts
+              return React.createElement(decorate.component, { ...props, ...getAndSetState })
+            }
+          }
+        }
+      })
+    ],
+    MentionSuggestions
+  ]
+}
+
+export { defaultSuggestionsFilter }


### PR DESCRIPTION
基于 [draft-js-mention](https://github.com/draft-js-plugins/draft-js-plugins/tree/master/packages/mention) 实现的 Mention 功能

`options` 除了可以使用 includeEditors 和 excludeEditors 指定和排除 editor 外，其余的参数传递给 draft-js-mention-plugin

变更文件说明：

- build/webpack.production.js 打包配置 增加 mention 模块的输出
- playground/index.jsx 测试及演示示例
- src/mention/index.jsx mention 模块主要实现代码
- README.md 模块使用说明
- package.json 增加依赖 draft-js-mention-plugin

相关 #34 